### PR TITLE
Add cabal file with a data-file for the lib. cabal install works. Library can be imported with fay --include

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cabal-dev
+dist

--- a/Language/Fay/JQuery.hs
+++ b/Language/Fay/JQuery.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE EmptyDataDecls    #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
 module Language.Fay.JQuery  where
 
 {--
@@ -5,8 +8,8 @@ Note that this is very much in flux. Function names, type signatures, and
 data types all subject to drastic change.
 --}
 
-import Language.Fay.Prelude
-import Language.Fay.FFI
+import           Language.Fay.FFI
+import           Language.Fay.Prelude
 
 data JQuery
 instance Foreign JQuery where
@@ -77,7 +80,7 @@ removeAttr = ffi "%2.removeAttr(%1)"
 removeClass :: String -> JQuery -> Fay JQuery
 removeClass = ffi "%2.removeClass(%1)"
 
-removeClassWith :: (Double -> String -> Fay JQuery) -> JQuery -> Fay JQuery 
+removeClassWith :: (Double -> String -> Fay JQuery) -> JQuery -> Fay JQuery
 removeClassWith = ffi "%2.removeClass(%1)"
 
 removeProp :: String -> JQuery -> Fay JQuery
@@ -183,10 +186,10 @@ getInnerWidth :: JQuery -> Fay Double
 getInnerWidth = ffi "%1.innerWidth()"
 
 -- TODO: figure out how to marshal coordinates
---getOffset :: JQuery -> Fay 
+--getOffset :: JQuery -> Fay
 --getOffset = ffi "%1.offset()"
 
---setOffset 
+--setOffset
 --setOffsetWith
 
 -- TODO: css with map

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/fay-jquery.cabal
+++ b/fay-jquery.cabal
@@ -1,0 +1,20 @@
+name:                fay-jquery
+version:             0.1.0.0
+-- synopsis:
+-- description:
+homepage:            https://github.com/brianhv/fay-jquery
+bug-reports:         https://github.com/brianhv/fay-jquery/issues
+-- license:
+--license-file:        LICENSE
+author:              Brian Victor
+ maintainer:         Brian Victor
+-- copyright:
+build-type:          Simple
+cabal-version:       >=1.8
+
+data-files:
+  Language/Fay/JQuery.hs
+
+library
+  other-modules: Language.Fay.JQuery
+  build-depends: fay

--- a/test.hs
+++ b/test.hs
@@ -61,7 +61,7 @@ isDivisibleBy num divisor = if num == 0 then True
 zebraStripeRows :: Double -> String -> Fay String
 zebraStripeRows index _ = return $ if isDivisibleBy index 2 then "odd" else "even"
 
-addZebraStriping = JQuery -> Fay JQuery
+addZebraStriping :: JQuery -> Fay JQuery
 addZebraStriping table = do
     --addClassWith zebraStripeRows rows
     evenRows <- findSelector "tr:even" table


### PR DESCRIPTION
With this the library can be `cabal install`'ed and used anywhere. Here's how I typecheck with GHC and compile with fay:

```
ghc cabal-dev/share/fay-jquery-0.1.0.0/ test.hs
fay --include=cabal-dev/share/fay-jquery-0.1.0.0/ test.hs
```

The goal is to make this automatic so fay can find the paths to libs through Cabal. And add type checking to the fay executable so you don't need to call `ghc`.

Feel free to fill in the blanks in the .cabal file.

Thanks for working on this by the way! With this change I can start using it in the snaplet-fay example for instance :)
