### PR TITLE
Added currentTarget function

### DIFF
--- a/src/JQuery.hs
+++ b/src/JQuery.hs
@@ -612,6 +612,9 @@ preventDefault = ffi "%1['preventDefault']()"
 target :: Event -> Fay Element
 target = ffi "%1['target']"
 
+currentTarget :: Event -> Fay Element
+currentTarget = ffi "%1['currentTarget']"
+
 timeStamp :: Event -> Fay Double
 timeStamp = ffi "%1['timeStamp']"
 


### PR DESCRIPTION
I found myself in a situation in which I needed the currentTarget function. When you use onDelegate to add click events to future tags you may need currentTarget when your click events is triggered by a child element. In that case delegateTarget points to the parent element in which the newly generated elements are found (for example "body"). You could of course use parentSelector to find the parent with the right selector to which the event is bound, but simply using currentTarget is easier.
